### PR TITLE
Documents must have filenames

### DIFF
--- a/__tests__/spec.files.js
+++ b/__tests__/spec.files.js
@@ -44,12 +44,13 @@ files.forEach((file) => {
 
     test('has correct document props', () => {
       documents.forEach((document) => {
-        expect(Object.keys(document)).toEqual([
-          'title',
-          'slug',
+        expect(Object.keys(document).sort()).toEqual([
           'description',
-          'tags',
           'editions',
+          'filename',
+          'slug',
+          'tags',
+          'title',
         ]);
       });
     });
@@ -64,7 +65,7 @@ files.forEach((file) => {
 
     test('document props are correct type', () => {
       documents.forEach((document) => {
-        ['title', 'slug', 'description']
+        ['title', 'slug', 'description', 'filename']
           .forEach(key => expect(typeof document[key]).toBe('string'));
 
         ['tags', 'editions']

--- a/src/en/ambrose-rigge.yml
+++ b/src/en/ambrose-rigge.yml
@@ -4,6 +4,7 @@ description: Ambrose Rigge (1635-1705) was early convinced of the truth through 
 documents:
   -
     title: The Journal and Writings of Ambrose Rigge
+    filename: Journal_of_Ambrose_Rigge
     slug: journal
     description: Ambrose Rigge (1635-1705) was early convinced of the truth through the preaching of George Fox, and grew to be a powerful minister of the gospel, a faithful elder, and a great sufferer for the cause of Christ. In one of his letters, he writes, "I have been in eleven prisons in this county, one of which held me ten years, four months and upward, besides twice premunired, and once publicly lashed, and many other sufferings too long to relate here." Yet through all he kept the faith, and served the Lord's body even while in bonds, through letters and papers given to encourage and establish the flock. Ambrose Rigge was one of many in his generation who sold all to buy the Pearl of great price, and having found true treasure, he kept it till the end.
     tags:

--- a/src/en/ann-branson.yml
+++ b/src/en/ann-branson.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of Ann Branson
     slug: journal
+    filename: Journal_of_Ann_Branson
     description: Ann Branson (1808-1891) was one of the very last, true ministers (being prepared, called, and used of the Lord) in a greatly reduced and sadly degenerate Society. Her deepest cry to the Lord, from the days of her childhood, was that "His eye would not pity, nor His hand spare" till He had thoroughly cleansed her heart, and made her a useful vessel in His house. Humbling herself before God and men, she was exalted by the Lord as a powerful and prophetic minister, something of a "last of the Mohicans" among the Quakers, even while, all around her, the 200 year old lampstand of the Society of Friends slowly and tragically burned out.
     tags:
       - journal

--- a/src/en/catherine-evans.yml
+++ b/src/en/catherine-evans.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Sufferings of Catherine Evans and Sarah Cheevers
     slug: sufferings-of-catharine-evans-sarah-cheevers
+    filename: Sufferings_of_Catharine_Evans_and_Sarah_Cheevers
     description: Catherine Evans (1618-1692) & Sarah Cheevers (1608-1664) were early ministers in the Society of Friends who embarked together on a missionary journey, intending for Alexandria, Egypt. After enduring several storms, their ship stopped at Malta, an island then under the control of the Catholic Church. Evans and Cheevers were arrested on the island for preaching and handing out spiritual literature, and placed under house arrest. After three months, they were moved to a local prison where they endured nearly four years of cruel treatment at the hands of the Inquisition in attempting to force their conversion to Catholicism.
     tags:
       - history

--- a/src/en/catherine-payton-phillips.yml
+++ b/src/en/catherine-payton-phillips.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Life and Letters of Catherine Phillips
     slug: life-and-letters
+    filename: Journal_of_Catherine_Phillips
     description: Catherine Phillips (1727-1794 — better known by her maiden name, Catherine Payton) was a highly gifted minister in the Society of Friends, who traveled almost continually for forty years in the service of Truth throughout England, Ireland, and North America. Her journal and letters clearly evince a life entirely surrendered to the cross of Christ, a mind supplied with wisdom and utterance from on high, and a heart filled with love for God and for mankind.
     tags:
       - journal
@@ -71,6 +72,7 @@ documents:
   -
     title: Letter to a Backslidden Brother
     slug: letter-to-backslidden-brother
+    filename: Letter_to_Backslidden_Brother
     description: This letter was written by Catherine Phillips in 1753 to her brother Henry Payton, who had "strayed from the path of peace and safety, to seek satisfaction in the grasp of empty bubbles, which had assumed the form, in his sight, of something substantial."
     tags:
       - letters

--- a/src/en/charles-marshall.yml
+++ b/src/en/charles-marshall.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of Charles Marshall
     slug: journal
+    filename: Journal_of_Charles_Marshall
     description: Charles Marshall (1637-1698) was convinced of the Truth at age seventeen by the powerful ministry of John Audland and John Camm, and eventually became a worthy minister and elder himself in the early Society of Friends. This short but instructive journal describes Marshall's progressive experience of the light of Jesus Christ, both as his judge and teacher, together with the several snares and temptations of the enemy that he met with along the way.
     tags:
       - journal
@@ -41,6 +42,7 @@ documents:
   -
     title: The Way of Life Revealed and the Way of Death Discovered
     slug: way-of-life-revealed
+    filename: Way_of_Life_Revealed
     description: The Way of Life Revealed And the Way of Death Discovered; Wherein is Declared Man's Happy Estate Before the Fall, His Miserable Estate in the Fall, and the Way of Restoration Out of the Fall, Into the Image of God Again, In Which Man Was Before the Fall.
     tags:
       - treatise

--- a/src/en/david-ferris.yml
+++ b/src/en/david-ferris.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Life of David Ferris
     slug: journal
+    filename: Life_of_David_Ferris
     description: David Ferris (1707-1779) was favored as a young child with a merciful visitation of the Lord whereby he was called out of the vanities of the world and enabled to see through the empty forms and superstitions of man-made religion. He was brought up a Presbyterian and educated in their way, but by attending to the inward teachings of divine grace, he became convinced of the principles of Friends (having no outward knowledge of their doctrines or practices), being clearly shown that the Lord was to be worshipped in spirit and truth by those who had been "judged according to men in the flesh, but live according to God in the Spirit." (1 Pet. 4:6). Being timid and diffident by nature, he resisted the Lord's call to ministry for many years, but at last gave up to preach the gospel as the Lord gave him utterance.
     tags:
       - journal

--- a/src/en/david-sands.yml
+++ b/src/en/david-sands.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Life and Gospel Labors of David Sands
     slug: journal
+    filename: Life_and_Gospel_Labors_of_David_Sands
     description: David Sands (1745-1816) was an active and influential minister in the Society of Friends at a time when the minds of many Friends had been corrupted from the original simplicity and purity of the gospel. Originally from Long Island, Sands labored extensively throughout New England, and also made a trip to Europe where he preached the gospel in England, Ireland, France, Germany, and several other parts of the continent. His life was fraught with many deep conflicts, difficulties, and opposition, but he remained a faithful and solid elder in the midst of a much deteriorated Society.
 
     tags:

--- a/src/en/elizabeth-stirredge.yml
+++ b/src/en/elizabeth-stirredge.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Life of Elizabeth Stirredge
     slug: journal-titip
+    filename: Journal_of_Elizabeth_Stirredge
     description: Elizabeth Stirredge (1634-1706) was not a traveling minister in the Society of Friends. She was a wife, a mother, and an extraordinary woman of God. This short but remarkable account of her life was written in the 56th year of her age for the benefit of her children and grandchildren. In it she describes her desperate search for the Lord in her younger days, her discovery of Truth, and some of the trials, persecutions, and joys she met with as she took up the daily cross and faithfully followed Christ.
     tags:
       - journal
@@ -41,6 +42,7 @@ documents:
   -
     title: The Life of Elizabeth Stirredge (Unabridged)
     slug: journal
+    filename: Unabridged_Journal_of_Elizabeth_Stirredge
     description: Elizabeth Stirredge (1634-1706) was not a traveling minister in the Society of Friends. She was a wife, a mother, and an extraordinary woman of God. This short but remarkable account of her life was written in the 56th year of her age for the benefit of her children and grandchildren. In it she describes her desperate search for the Lord in her younger days, her discovery of Truth, and some of the trials, persecutions, and joys she met with as she took up the daily cross and faithfully followed Christ.
     tags:
       - journal

--- a/src/en/elizabeth-webb.yml
+++ b/src/en/elizabeth-webb.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: A Letter of Elizabeth Webb
     slug: letter
+    filename: Letter_of_Elizabeth_Webb
     description: Elizabeth Webb (1663-1726) was a respected minister in the Society of Friends who travelled extensively in her service for the gospel. In 1712 she went from Pennsylvania to Great Britain to visit Friends, and while in London became acquainted with Anthony William Boehm, who was then chaplain to Prince George of Denmark. At some point after their meeting, Elizabeth Webb felt constrained in the love of God to write to Boehm and present him with this remarkable letter as something of a summary of her spiritual pilgrimage.
     tags:
       - journal

--- a/src/en/francis-howgill.yml
+++ b/src/en/francis-howgill.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: Some of the Mysteries of God's Kingdom Declared
     slug: mysteries-of-gods-kingdom-declared
+    filename: Mysteries_of_Gods_Kingdom_Declared
     description: Francis Howgill (1618–1668) was a powerful minister of the gospel in England who suffered great persecution and eventually died in prison for "the Word of God and for the testimony of Jesus." This short book contains a remarkable explanation of the Day of the Lord, and a powerful description of the Holy Spirit's work in the heart of man.
     tags:
       - treatise

--- a/src/en/george-fox.yml
+++ b/src/en/george-fox.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal and Writings of Ambrose Rigge
     slug: journal
+    filename: Journal_of_George_Fox
     description: This is George Fox's unabridged, two-volume journal. It is extremely long, and perhaps too exhaustive for some readers. But we highly recommend that you at least read the account of his early years, his call to the ministry, and the birth of the Society of Friends.
     tags:
       - journal

--- a/src/en/george-whitehead.yml
+++ b/src/en/george-whitehead.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Christian Progress of George Whitehead
     slug: journal
+    filename: Christian_Progress_of_George_Whitehead
     description: George Whitehead (1636-1723) was one of the most influential of the early Quakers. He was convinced of the Truth when only 17 years old, and grew quickly in the life and power of the gospel. Though publicly whipped, imprisoned multiple times, frequently abused and persecuted, he kept close to the cross, and came to be a pillar and elder in the church of God, constantly laboring for the advancement of Truth and the welfare of the Society.
     tags:
       - journal

--- a/src/en/henry-hull.yml
+++ b/src/en/henry-hull.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Journal of John Churchman
     slug: journal
+    filename: Life_and_Labors_of_Henry_Hull
     description: Henry Hull (1765-1834) loved the Lord from a young age, and was desirous to serve Him, but being diffident and shy by nature, was unwilling to give up to a call to the ministry until a voice sounded in the ear of his understanding, saying, "You are in great danger of being lost in your rebellion." At that moment, Henry put his hand to the plow and never looked back, saying, "Lord, do what You will with me, come life or death, I will give up all for Your sake." He travelled much in the ministry in different parts of the United States and Canada, and also crossed the Atlantic to visit the churches of God in Ireland and England. While in England, he met with the severe trial of receiving a letter informing him of the death of his wife, son, and mother, all by a malignant fever that had spread through his native land. Though deeply grieved by this heavy affliction, he was nevertheless enabled to say, "Though He slay me, yet I will trust in Him. It is the Lord, let Him do what seems good to Him."
     tags:
       - journal

--- a/src/en/isaac-martin.yml
+++ b/src/en/isaac-martin.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Journal of Isaac Martin
     slug: journal
+    filename: Journal_of_Isaac_Martin
     description: Isaac Martin (1758-1828) was a sweet-spirited minister in the Society of Friends. Having fallen from a two-story window ​and cracked his skull when a small child, he suffered agonizing pain in his head and eye for the great majority of his life. But despite his frequent ailments, he submitted whole-heartedly to Christ's baptism of Spirit and fire, and became a effective minister who depended entirely upon the power and direction of the Holy Spirit. On this subject he once wrote - "Unless I had felt ​the Lord's​ blessed presence to strengthen and qualify me, I would rather have laid down my life, than have attempted to minister to the people by virtue of any ​knowledge or abilit​y​, natural or acquired, which, as a man, I might possess.​"
     tags:
       - journal

--- a/src/en/isaac-penington.yml
+++ b/src/en/isaac-penington.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Writings of Isaac Penington - Volume 1
     slug: writings-volume-1
+    filename: Writings_of_Isaac_Penington_vol_1
     description: Isaac Penington (1616-1679) was the son of a prominent English politician, and the father-in-law of William Penn, founder of Pennsylvania. Though born into a family of wealth and reputation, Penington's heart was set upon things above from his earliest days. Even as a child, he recognized that the religion of his day stood in the will and understanding of man, in outward practices, duties, and scriptural truths that were professed but not truly possessed. Isaac Penington longed for more. Motivated by an insatiable hunger for truth, he sought the Lord with all his heart and discovered a Christianity that stood in, and flowed out from, the light and life of Jesus Christ reigning in the inner man.
     tags:
       - devotional
@@ -254,6 +255,7 @@ documents:
   -
     title: The Writings of Isaac Penington - Volume 2
     slug: writings-volume-2
+    filename: Writings_of_Isaac_Penington_vol_2
     description: Isaac Penington (1616-1679) was the son of a prominent English politician, and the father-in-law of William Penn, founder of Pennsylvania. Though born into a family of wealth and reputation, Penington's heart was set upon things above from his earliest days. Even as a child, he recognized that the religion of his day stood in the will and understanding of man, in outward practices, duties, and scriptural truths that were professed but not truly possessed. Isaac Penington longed for more. Motivated by an insatiable hunger for truth, he sought the Lord with all his heart and discovered a Christianity that stood in, and flowed out from, the light and life of Jesus Christ reigning in the inner man.
     tags:
       - devotional
@@ -489,6 +491,7 @@ documents:
   -
     title: The Unabridged Works of Isaac Penington - Volume 1
     slug: unabridged-works-volume-1
+    filename: Unabridged_Works_of_Isaac_Penington_vol_1
     description: Isaac Penington (1616-1679) was one of the most prolific and gifted writers among the early Quakers. The four publications here are the unabridged works Isaac Penington. These have not been edited, with the exception of some modernization of archaic words and spellings.
     tags:
       - devotional
@@ -547,6 +550,7 @@ documents:
   -
     title: The Unabridged Works of Isaac Penington - Volume 2
     slug: unabridged-works-volume-2
+    filename: Unabridged_Works_of_Isaac_Penington_vol_2
     description: Isaac Penington (1616-1679) was one of the most prolific and gifted writers among the early Quakers. The four publications here are the unabridged works Isaac Penington. These have not been edited, with the exception of some modernization of archaic words and spellings.
     tags:
       - devotional
@@ -625,6 +629,7 @@ documents:
   -
     title: The Unabridged Works of Isaac Penington - Volume 3
     slug: unabridged-works-volume-3
+    filename: Unabridged_Works_of_Isaac_Penington_vol_3
     description: Isaac Penington (1616-1679) was one of the most prolific and gifted writers among the early Quakers. The four publications here are the unabridged works Isaac Penington. These have not been edited, with the exception of some modernization of archaic words and spellings.
     tags:
       - devotional
@@ -673,6 +678,7 @@ documents:
   -
     title: The Unabridged Works of Isaac Penington - Volume 4
     slug: unabridged-works-volume-4
+    filename: Unabridged_Works_of_Isaac_Penington_vol_4
     description: Isaac Penington (1616-1679) was one of the most prolific and gifted writers among the early Quakers. The four publications here are the unabridged works Isaac Penington. These have not been edited, with the exception of some modernization of archaic words and spellings.
     tags:
       - devotional

--- a/src/en/james-dickinson.yml
+++ b/src/en/james-dickinson.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Journal of James Dickinson
     slug: journal
+    filename: Journal_of_James_Dickinson
     description: James Dickinson (1659-1741) was a well-known and much-beloved minister in the Society of Friends, whose long life was spent in tireless labor for the edification of the church and for the good of souls. In the service of the ministry, he travelled throughout England, Ireland, and Scotland; undergoing ​many ​sufferings in times of persecution. He visited Friends in Ireland twelve times, three times in America, once in Holland and ​also in ​Germany.​ ​His ministry was not in the enticing words which man's wisdom teaches, but in the demonstration of the Spirit and power, and was effectual to the convincing and gathering of many, whose hearts were settled on the Rock Christ Jesus, knowing Him to be their true light and teacher.
     tags:
       - journal

--- a/src/en/james-gough.yml
+++ b/src/en/james-gough.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Life and Gospel Labors of James Gough
     slug: journal
+    filename: Journal_of_James_Gough
     description: As a boy, James Gough (1712-1780) was known for his genius intellect, having mastered the Greek and Latin tongues when still a young child. At one point, after conversing with young James, a distinguished Justice of the Peace so admired his propensity for learning that he offered to pay his way through university. But although such flattery sowed seeds of pride and vain conceit in James' young heart, it pleased the Lord to visit him in power and love, and he was prevailed upon to give up all to follow Christ. James Gough became a wise and well-beloved minister among the Society of Friends, but having learned to live low at the feet of His Master, he was always remarkable for his deep humility, and low opinion of himself.
     tags:
       - journal

--- a/src/en/james-parnell.yml
+++ b/src/en/james-parnell.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: Memoir of James Parnell - With Letters and Writings
     slug: journal
+    filename: Memoir_of_James_Parnell
     description: James Parnell (1637-1656) is said to have been “young, small of stature, and poor in appearance,” but thousands were made to confess that “he spoke as one having authority, and not as the scribes.” He was convinced of the Truth when only fourteen years of age, and became a mighty preacher and promoter of the gospel by sixteen. Following a debate with a prominent priest, Parnell was arrested on spurious charges of being an “idle and disorderly person,” and imprisoned at Colchester Castle. There he was confined to a small hole in the thick castle wall, twelve feet above the ground. He died from sickness and ill-treatment after ten months imprisonment at the young age of nineteen.
     tags:
       - journal

--- a/src/en/jane-pearson.yml
+++ b/src/en/jane-pearson.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Life and Experiences of Jane Pearson
     slug: journal
+    filename: Life_and_Experiences_of_Jane_Pearson
     description: The story of Jane Pearson (1735–1816) is both heartbreaking and deeply inspiring. Her life was fraught with inward and outward sorrows beyond description. For fourteen years she wrestled with a host of inward enemies as she sought to know and be conformed to the Beloved of her soul. And when at last she saw a measure of peace and stability in the Truth, she was then made to suffer the loss of her dear husband and seven children to a variety of illnesses. But the more she lost of the world, the more she seemed to gain of Christ, and her experiences of His closeness and kindness to her are indescribably beautiful.
     tags:
       - journal

--- a/src/en/job-scott.yml
+++ b/src/en/job-scott.yml
@@ -5,7 +5,8 @@ documents:
   -
     title: The Journal of Job Scott
     slug: journal
-    description: Job Scott (1751-1793) was a gifted and well-beloved minister in the Society of Friends in America. He was known for his total dependence upon the immediate moving and empowering of the Holy Spirit, and his unwillingness to minister without a clear sense of the Lord's will. On occasions, while preaching, he would suddenly stop speaking and sit down, explaining later that, having lost a sense of the authority and direction of the Spirit of God, he could do nothing without it. The writings in his journal are weighty and living, and have no doubt comforted and helped many weary travelers on the road to Zion. Job Scott died of Smallpox on a ministry trip to Ireland in 1793. 
+    filename: Journal_of_Job_Scott
+    description: Job Scott (1751-1793) was a gifted and well-beloved minister in the Society of Friends in America. He was known for his total dependence upon the immediate moving and empowering of the Holy Spirit, and his unwillingness to minister without a clear sense of the Lord's will. On occasions, while preaching, he would suddenly stop speaking and sit down, explaining later that, having lost a sense of the authority and direction of the Spirit of God, he could do nothing without it. The writings in his journal are weighty and living, and have no doubt comforted and helped many weary travelers on the road to Zion. Job Scott died of Smallpox on a ministry trip to Ireland in 1793.
     tags:
       - journal
     editions:

--- a/src/en/john-banks.yml
+++ b/src/en/john-banks.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal and Epistles of John Banks
     slug: journal
+    filename: Journal_of_John_Banks
     description: John Banks (1637-1710) was another faithful and influential minister among the first generation of Quakers. "After it had pleased the eternal, wise God to open his understanding, and to let him see his own state and condition, and reveal his Son in him, he was made willing to give up freely to the heavenly and inward appearance of Christ Jesus, the hope of glory. And as he was obedient thereunto, he was entrusted with a large gift of the ministry, in which he grew, and was made powerful in it, to the turning of many unto the right way of the Lord who were convinced of the evil of their ways, and turned unto Jesus Christ, their free Teacher, and were made to bless the Lord on his behalf." (Testimony of intimate friend, John Bousted)
     tags:
       - journal

--- a/src/en/john-barclay.yml
+++ b/src/en/john-barclay.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal and Letters of John Barclay
     slug: journal
+    filename: Journal_of_John_Barclay
     description: John Barclay (1797-1838), though a descendent of the well-known Barclay family, was a complete stranger to the life and power of Truth until he began to seek the Lord with all his heart, somewhere around his 18th year. The Society of Friends at that time was in a sad and declining state, but John Barclay dug deep and found the Root of life from which early Quakers had sprouted, and became a living branch himself, and a very useful minister. He lived only 41 years, but his short life was wholly dedicated to his Master's cause, and many of the journals, memoirs, and biographies of Early Friends are the fruit of his arduous and faithful labor with the original documents.
     tags:
       - journal

--- a/src/en/john-burnyeat.yml
+++ b/src/en/john-burnyeat.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of John Burnyeat
     slug: journal
+    filename: Journal_of_John_Burnyeat
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal
@@ -29,6 +30,7 @@ documents:
   -
     title: The Unabridged Journal and Letters of John Burnyeat
     slug: unabridged-journal-and-letters
+    filename: Unabridged_Journal_of_John_Burnyeat
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal

--- a/src/en/john-churchman.yml
+++ b/src/en/john-churchman.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Journal of John Churchman
     slug: journal
+    filename: Journal_of_John_Churchman
     description: John Churchman (1705-1775) was a man whose entire life was devoted to the increase of Christ's kingdom in the hearts of men. Having experienced the spiritual baptism which is essential to salvation, and abiding in a state of watchfulness and humility, he became (under the Lord's anointing) a well qualified instrument for the instruction and edification of others in the way of life and godliness. By attending to the gift of gospel ministry committed to his trust, and performing the duties required of him, he witnessed a growth from stature to stature, and became an upright elder and father in the church, being an example to all in word, in conduct, in spirit, in faith and ​in love.
     tags:
       - journal

--- a/src/en/john-gratton.yml
+++ b/src/en/john-gratton.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of John Gratton
     slug: journal
+    filename: Journal_of_John_Gratton
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal

--- a/src/en/john-griffeth.yml
+++ b/src/en/john-griffeth.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: John Griffeth's Early Years & Spiritual Growth
     slug: early-years-and-spiritual-growth
+    filename: Journal_of_John_Griffith
     description: This instructive portion of his lengthy journal deals with his conversion, spiritual growth, and call to the ministry.
     tags:
       - journal
@@ -42,6 +43,7 @@ documents:
   -
     title: The Complete Journal of John Griffeth
     slug: journal
+    filename: Unabridged_Journal_of_John_Griffith
     description: This is the unabridged journal of John Griffith, with modernization of spellings and some archaic words.
     tags:
       - journal
@@ -82,6 +84,7 @@ documents:
   -
     title: Remarks on Parenting, New Birth, Worship, Ministry, & Discipline
     slug: remarks
+    filename: Some_Brief_Remarks
     description: This treatise, written by John Griffith in 1762, contains weighty and helpful counsel on the subjects of parenting, the new birth, the nature of true worship, true and false ministry, and the nature and usefulness of Christian discipline.
     tags:
       - treatise

--- a/src/en/john-richardson.yml
+++ b/src/en/john-richardson.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: John Richardson's Early Years & Spiritual Growth
     slug: early-years-and-spiritual-growth
+    filename: Journal_of_John_Richardson
     description: This instructive portion is an excerpt from his journal relating his early years, spiritual growth, and call to ministry.
     tags:
       - journal
@@ -42,6 +43,7 @@ documents:
   -
     title: The Complete Journal of John Richardson
     slug: journal
+    filename: Unabridged_Journal_of_John_Richardson
     description: This is the unabridged journal of John Richardson, with modernization of spellings and some archaic words.
     tags:
       - journal

--- a/src/en/john-spalding.yml
+++ b/src/en/john-spalding.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: A Few Reasons for Leaving the Established Mode of Worship
     slug: a-few-reasons-for-leaving
+    filename: A_Few_Reasons_for_Leaving
     description: A Few Reasons for Leaving the National Established Mode of Worship, Addressed to the professors of religion in this day, by one who was long in the profession, but knew not the power, till it pleased the Lord, by the ministry and writings of the people called Quakers, to direct him to where alone the power is to be known, that is, within.
     tags:
       - letter

--- a/src/en/john-woolman.yml
+++ b/src/en/john-woolman.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal and Writings of John Woolman
     slug: journal
+    filename: Journal_and_Publications_of_John_Woolman
     description: John Woolman (1720-1772) is one of the most well known Quakers of the 1700's because of his writings against slavery and other social evils. Unfortunately, many edited versions of his journal exist online and in print today which have removed many aspects of his Christian faith and experience, rendering him little more than a philanthropist and abolitionist. The truth is that John Woolman was a devoted servant of Jesus Christ, a preacher of truth and righteousness, and a man filled with the Spirit and love of God that overflowed towards his fellow creatures. The document provided here contains his unabridged journal and works.
     tags:
       - journal

--- a/src/en/joseph-oxley.yml
+++ b/src/en/joseph-oxley.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Journal of Joseph Oxley
     slug: journal
+    filename: Journal_of_Joseph_Oxley
     description: Joseph Oxley (1715–1776) was a humble and sweet-spirited minister in the Society of Friends, whose life and service in the church manifested a total reliance upon the immediate empowering of the Spirit of Christ. Though he had a low opinion of himself, he was highly regarded and respected by all, and his ministry was known to be accompanied by that heavenly power which both confutes the proud and raises up the humble. He was led to preach the gospel in England, Ireland, Scotland, and the American Colonies, where his services were said to have "proceeded from the influence of the Minister of the sanctuary and true tabernacle, which God has pitched and not man."
     tags:
       - journal

--- a/src/en/joseph-phipps.yml
+++ b/src/en/joseph-phipps.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Original and Present State of Man
     slug: original-and-present-state-of-man
+    filename: Original_and_Present_State_of_Man
     description: This remarkable little book sheds much light upon the nature of man's fall, the necessity, means, and manner of his restoration through the sacrifice of Christ, and the discernible operation of the Divine Spirit of grace and truth.
     tags:
       - doctrinal

--- a/src/en/joseph-pike.yml
+++ b/src/en/joseph-pike.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: An Account of the Life of Joseph Pike
     slug: journal
+    filename: Journal_of_Joseph_Pike
     description: Joseph Pike (1657-1729) was a valuable elder and minister in the Society of Friends. He was born in the year 1657, near Cork, in Ireland. In his old age he wrote an account of his early years and growth in the truth, chiefly for the benefit of his own children. This short but valuable account describes how he was first confronted and convinced of the Truth by the Lord, and then how he became progressively more familiar with, and obedient to, the light, life, and power of Christ working within.
     tags:
       - journal

--- a/src/en/martha-routh.yml
+++ b/src/en/martha-routh.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Life of Martha Routh
     slug: journal
+    filename: Journal_of_Martha_Routh
     description: Martha Routh (1743-1817) was working as the head of a Friend's boarding school in Nottingham, England when, at age of 30, she was called into the ministry. The remaining 44 years of her life were devoted to traveling and preaching the gospel throughout all parts of England, Wales, Scotland, Ireland, and America. Her first trip to America was in 1794, where she labored for over three years, traveling over 11,000 miles, before returning to her native country. She returned to America in 1801 with her husband (who died shortly after arrival in New York). Martha Routh's life was exemplary in every respect, and her preaching was "in demonstration of the Spirit and of power."
     tags:
       - journal

--- a/src/en/mary-dudley.yml
+++ b/src/en/mary-dudley.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal and Letters of Mary Dudley
     slug: journal
+    filename: Journal_of_Mary_Dudley
     description: Mary Dudley (1750-1823) was a seeker of truth and righteousness from her earliest days. When around 20 years old, she joined the Methodists for two or three years, and was much esteemed by John Wesley for her humble devotion and pious example. She soon found, however, that their active and outward zeal was not compatible with the spiritual poverty she felt in herself, and the great need she had seen for total dependence upon the Spirit of God for all true worship and ministry. Finding a home among the Quakers, she grew to become a powerful minister and a "mother in Israel", pointing many to the covenant of light and life in Jesus Christ.
     tags:
       - journal

--- a/src/en/mary-neale.yml
+++ b/src/en/mary-neale.yml
@@ -6,6 +6,7 @@ documents:
   -
     title: The Life and Letters of Mary Neale
     slug: journal
+    filename: Journal_of_Mary_Paisley_Neale
     description: Mary Neale (1717-1757), dying only three days after her marriage to Samuel Neale, is best known by her maiden name, Mary Peisley. Having been early turned from the pursuit of worldly pleasures and vanity by the inward appearing of the Lord Jesus, Mary Neale surrendered all to the cross of Christ and was made by Him a shining example of a true gospel minister. Of her life, James Gough (another minister in the Society of Friends) wrote, "I am ready to conclude that none in our day, from the time of the effectual visitation of Christ in her soul, adhered with more steadiness to His guidance, through a variety of probations."
     tags:
       - journal

--- a/src/en/rebecca-jones.yml
+++ b/src/en/rebecca-jones.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Diary and Letters of Rebecca Jones
     slug: diary-and-letters
+    filename: Journal_of_Rebecca_Jones
     description: The diary and letters of Rebecca Jones are both endearing and instructive, telling the story of a meek disciple, a powerful preacher, a tireless minister, a loving "mother in Israel", and an shining example of innocence, love, humility, and faithfulness to the Lord Jesus Christ.
     tags:
       - journal

--- a/src/en/richard-davies.yml
+++ b/src/en/richard-davies.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of Richard Davies
     slug: journal
+    filename: Journal_of_Richard_Davies
     description: Richard Davies (1635–1708) was another who desperately sought after Truth from his earliest days, and became the first Welshmen to be convinced of the principles preached by the Early Quakers. Through many hardships (beatings, mockings, long imprisonments, etc.) he grew up in the Lord and became a eminent minister in the Society of Friends, being so filled with the Lord's humility and love that even his enemies respected and admired him.
     tags:
       - journal

--- a/src/en/robert-barclay.yml
+++ b/src/en/robert-barclay.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: Waiting Upon the Lord
     slug: waiting-upon-the-lord
+    filename: Waiting_Upon_the_Lord
     description: Robert Barclay writes, “All true and acceptable worship to God is offered in the inward and immediate moving and drawing of His own Spirit.” It is not hard to agree with such a statement, but who has indeed stood still to see the salvation of the Lord, and known the dawning of His inward Day? Have we waited upon our God to separate the precious from the vile within, to differentiate between the pure operation of His Spirit and the wild rovings of our own soul? Have we truly known and obeyed His inward stirrings and teachings, or does the Seed of God lay buried in Christian hearts beneath a mass of superstition, assumption, and fleshy, religious activity?
     tags:
       - doctrinal
@@ -52,6 +53,7 @@ documents:
   -
     title: Saved to the Uttermost
     slug: saved-to-the-uttermost
+    filename: Saved_to_the_Uttermost
     description: Robert Barclay's "Apology for the True Christian Divinity" is perhaps the most well-known of all Friends' writings. "Saved to the Uttermost" (which is taken from propositions four through eight of the Apology) brilliantly expounds some of the most vital and misunderstood aspects of Christianity, plainly manifesting the true nature, experience, and extent of the salvation that God offers the soul through Jesus Christ.
     tags:
       - doctrinal
@@ -153,6 +155,7 @@ documents:
   -
     title: Apology for the True Christian Divinity
     slug: apology
+    filename: Apology
     description: Robert Barclay (1648–1690) was a Scottish Quaker, and one of the most eminent writers in the Society of Friends. His "Apology for the True Christian Divinity" is perhaps the most well-known of all Quaker writings, containing a thorough explanation and defense of most of their principles and doctrines. The eBook edition provided here is unabridged, but some archaic words and spellings have been modernized by Market Street Fellowship.
 
     tags:
@@ -223,6 +226,7 @@ documents:
   -
     title: Considerations upon Recreation and Entertainment
     slug: recreation-and-entertainment
+    filename: Recreation_and_Entertainment
     description: This is a short extract from the fifteenth proposition of Robert Barclay's "Apology for the True Christian Divinity" regarding entertainment and recreation.
     tags:
       - doctrinal

--- a/src/en/stephen-crisp.yml
+++ b/src/en/stephen-crisp.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: The Journal of Stephen Crisp
     slug: journal
+    filename: Journal_of_Stephen_Crisp
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal
@@ -30,6 +31,7 @@ documents:
   -
     title: A Plain Pathway
     slug: plain-pathway
+    filename: Plain_Pathway
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - exhortation

--- a/src/en/thomas-story.yml
+++ b/src/en/thomas-story.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: Thomas Story's Early Years & Spiritual Growth
     slug: early-years-and-spiritual-growth
+    filename: Journal_of_Thomas_Story
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal
@@ -29,6 +30,7 @@ documents:
   -
     title: Thomas Story's Journal
     slug: journal
+    filename: Unabridged_Journal_of_Thomas_Story
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     tags:
       - journal
@@ -49,6 +51,7 @@ documents:
   -
     title: Salvation By Christ
     slug: salvation-by-christ
+    filename: Salvation_by_Christ
     description: An excerpt from the journal of Thomas Story, concerning salvation by Christ.
     tags:
       - doctrinal
@@ -69,6 +72,7 @@ documents:
   -
     title: Letter to a Doubter
     slug: letter-to-a-doubter
+    filename: Letter_to_a_Doubter
     description: An excerpt from the journal of Thomas Story.
     tags:
       - exhortation

--- a/src/en/william-penn.yml
+++ b/src/en/william-penn.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: No Cross, No Crown
     slug: no-cross-no-crown
+    filename: No_Cross_No_Crown
     description: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor.
     tags:
       - treatise

--- a/src/es/isaac-penington.yml
+++ b/src/es/isaac-penington.yml
@@ -5,6 +5,7 @@ documents:
   -
     title: Los Escritos de Isaac Penington — Volumen 1
     slug: escritos-volume-1
+    filename: Escritos_de_Isaac_Penington_vol_1
     description: Isaac Penington (1616–1679) fue criado en una familia rica e influyente, y cultivado y pulido con una buena y amplia educación. Sin embargo, las aspiraciones de Penington, desde sus primeros días, estaban enteramente fijadas en las cosas de arriba y no en las muchas cosas del mundo que estaban a su alcance. Él dice de sí mismo — “Desde mi niñez mi corazón fue apuntado hacia el Señor, de quien me ocupé y a quien busqué desde mis tiernos años. Yo sentía que no podía estar satisfecho con (ni buscar) las cosas de este mundo perecedero, las cuales naturalmente expiran, sino que deseaba un verdadero sentido y unidad con lo que permanece para siempre.” De hecho, el hambre y la desesperación de Penington por el verdadero conocimiento y experiencia de Dios fue un sello distintivo en su vida. Buscando, encontró; llamando, la puerta se abrió delante de él. Buscó al Señor con todo su corazón, mente y fuerza, y no cabe duda de que el Señor fue encontrado por él.
     tags:
       - devotional


### PR DESCRIPTION
@Henderjay this PR introduces a new required concept -- now each document needs a `filename` attribute.  This corresponds to the _base_ portion of the filename (minus the `--{edition}` suffix from the files in Sync:

![2018-03-14_21-17-21](https://user-images.githubusercontent.com/7050938/37439178-3e4acd66-27cd-11e8-97f7-8def52a2dbac.png)

Maybe click the **Files Changed** tab above and take a quick gander (you can skip the first javascript file which is just where I made the tests fail if there is no filename -- just look at the `.yml` files) to familiarize yourself.

Once this gets merged, your tests won't pass unless any new documents you add also contain this attribute. I realized not long ago I need this scrap of data to reliably connect everything together to get the deployed files connected and actually reliably downloading from the site, which is what I'm currently working on.